### PR TITLE
Add a link to Cron Expression Generator & Explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ If a container is found to have the label `cron.schedule` then it will be added 
 
 Cron scheduling rules follow: [Expression Format](https://godoc.org/github.com/robfig/cron#hdr-CRON_Expression_Format)
 
+Use [Cron Expression Generator & Explainer](https://www.freeformatter.com/cron-expression-generator-quartz.html) to quickly generate cron expressions and convert them to readable text format.
+
 ### Rancher Mode:
 When running in Rancher mode, the service watches Rancher metadata for service state. If the service is in any other mode
 then Active, then the job is disabled. 
@@ -35,7 +37,7 @@ there is a 5 second window for the job to be re-activated.
 
 ## Override labels that can be applied
 
-To override the default start action on the container, set the label `cron.action` equal to ``stop` or `restart`.
+To override the default start action on the container, set the label `cron.action` equal to `stop` or `restart`.
 
 To override the default 10 second restart/stop timeout set the label `cron.restart_timeout` to the number of
 seconds you would like. For instance for 20 seconds: `cron.restart_timeout=20`.


### PR DESCRIPTION
This is handy from a user perspective.

Also snuck in a minor typo fix.