### PR TITLE
fixed setJobState method for sidekicks

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -2,6 +2,7 @@ package cron
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Sirupsen/logrus"
@@ -153,7 +154,11 @@ func (ct *Crontab) setJobState(job *JobEntry) {
 	}
 
 	stackName := getRancherStackNameFromLabels(job.Job.Labels)
-	serviceName := getRancherServiceNameFromLabels(job.Job.Labels)
+
+	// The return value of getRancherServiceNameFromLabels for a sidekick is something like "mainname/sidekickname"
+	// but we only need "sidekickname" for this to work in the sidekick case
+	serviceStackName := strings.Split(getRancherServiceNameFromLabels(job.Job.Labels), "/")
+	serviceName := serviceStackName[len(serviceStackName)-1]
 	if stackName != "" && serviceName != "" {
 		state, err := ct.checkRancherMetadataServiceState(stackName, serviceName)
 		if err != nil {

--- a/events/router.go
+++ b/events/router.go
@@ -40,15 +40,15 @@ loop:
 		ctx, cancelFunc := context.WithCancel(context.Background())
 		eventStream, errChan := router.Listen(ctx)
 		for {
-		select {
-		case event := <-eventStream:
-			handler.Handle(&event)
-		case err := <-errChan:
-			logrus.Error(err)
-			cancelFunc()
-			continue loop
+			select {
+			case event := <-eventStream:
+				handler.Handle(&event)
+			case err := <-errChan:
+				logrus.Error(err)
+				cancelFunc()
+				continue loop
+			}
 		}
-	}
 	}
 }
 


### PR DESCRIPTION
Version 0.3.0 broke cron scheduling for sidekicks. This PR is fixing this bug. 

The return value of getRancherServiceNameFromLabels for a sidekick is something like "mainname/sidekickname" but we only need "sidekickname" for this to work.

I would appreciate a 0.3.1 release with this changes.

Additional Changes:
- fixed dapper build by formating the sources properly