### PR TITLE
Handle stack / service renames in Rancher mode

### DIFF
--- a/cron/docker.go
+++ b/cron/docker.go
@@ -12,14 +12,15 @@ import (
 
 // DockerJob implements the cron job interface
 type DockerJob struct {
-	ID             string
-	Action         string
-	Schedule       string
-	Leader         bool
-	Labels         map[string]string
-	Active         bool
-	lastError      error
-	restartTimeout time.Duration
+	ID                 string
+	Action             string
+	Schedule           string
+	Leader             bool
+	Labels             map[string]string
+	RancherServiceUUID string
+	Active             bool
+	lastError          error
+	restartTimeout     time.Duration
 }
 
 // Err returns last error message


### PR DESCRIPTION
This gets the service UUID the first time it is run and stores that.
All subsequent state checks will be done with the UUID which stays the
same after stack/service renames.