### PR TITLE
adding the option to define a label namespace

### DIFF
--- a/cron/cron.go
+++ b/cron/cron.go
@@ -65,7 +65,7 @@ func (ct *Crontab) GetEntries() []cron.Entry {
 }
 
 // AddJob Adds a docker job to the crontab
-func (ct *Crontab) AddJob(id string, labels map[string]string, jobType string) error {
+func (ct *Crontab) AddJob(id string, labels map[string]string, jobType string, labelNamespace string) error {
 	var job *DockerJob
 
 	if _, ok := ct.jobs[id]; ok {
@@ -73,14 +73,14 @@ func (ct *Crontab) AddJob(id string, labels map[string]string, jobType string) e
 		return nil
 	}
 
-	schedule, ok := labels["cron.schedule"]
+	schedule, ok := labels[labelNamespace + ".schedule"]
 	if !ok {
 		return fmt.Errorf("No cron schedule found for container: %s", id)
 	}
 
 	switch jobType {
 	case "docker":
-		job = NewDockerJob(id, labels)
+		job = NewDockerJob(id, labels, labelNamespace)
 	default:
 		logrus.Warnf("Unknown job type: %s", jobType)
 	}

--- a/cron/docker.go
+++ b/cron/docker.go
@@ -15,6 +15,7 @@ type DockerJob struct {
 	ID                 string
 	Action             string
 	Schedule           string
+	LabelNamespace     string
 	Leader             bool
 	Labels             map[string]string
 	RancherServiceUUID string
@@ -93,10 +94,11 @@ func getDockerClient() (*client.Client, error) {
 }
 
 // NewDockerJob creates a DockerJob and sets defaults
-func NewDockerJob(id string, labels map[string]string) *DockerJob {
+func NewDockerJob(id string, labels map[string]string, labelNamespace string) *DockerJob {
 	dj := &DockerJob{
 		ID:             id,
-		Schedule:       labels["cron.schedule"],
+		Schedule:       labels[labelNamespace + ".schedule"],
+		LabelNamespace: labelNamespace,
 		Labels:         labels,
 		Action:         "start",
 		Leader:         false,
@@ -105,15 +107,15 @@ func NewDockerJob(id string, labels map[string]string) *DockerJob {
 		restartTimeout: getDuration(10),
 	}
 
-	if value, ok := labels["cron.action"]; ok {
+	if value, ok := labels[labelNamespace + ".action"]; ok {
 		dj.Action = value
 	}
 
-	if _, ok := labels["cron.leader"]; ok {
+	if _, ok := labels[labelNamespace + ".leader"]; ok {
 		dj.Leader = true
 	}
 
-	if TO, ok := labels["cron.restart_timeout"]; ok {
+	if TO, ok := labels[labelNamespace + ".restart_timeout"]; ok {
 		i, err := strconv.Atoi(TO)
 		if err != nil {
 			logrus.Error("Error converting cron.restart_timeout to int, sticking with default of 10seconds")

--- a/events/router.go
+++ b/events/router.go
@@ -33,7 +33,7 @@ func NewEventRouter() (Router, error) {
 }
 
 // StartRouter calls the listener function and takes the interface for testing
-func StartRouter(router Router, handler Handler) {
+func StartRouter(router Router, handler Handler, labelNamespace string) {
 
 loop:
 	for {
@@ -42,7 +42,7 @@ loop:
 		for {
 			select {
 			case event := <-eventStream:
-				handler.Handle(&event)
+				handler.Handle(&event, labelNamespace)
 			case err := <-errChan:
 				logrus.Error(err)
 				cancelFunc()

--- a/main.go
+++ b/main.go
@@ -37,6 +37,11 @@ func main() {
 			Usage: "Allow Rancher ",
 		},
 		cli.StringFlag{
+			Name:  "label-namespace,ln",
+			Value: "cron",
+			Usage: "Label Namespace, default: 'cron'",
+		},
+		cli.StringFlag{
 			Name:  "metadata-url",
 			Value: MetadataURL,
 			Usage: "Provide full URL of Metadata",
@@ -52,6 +57,7 @@ func main() {
 func start(c *cli.Context) error {
 	handler, err := events.NewDockerHandler(&events.DockerHandlerOpts{
 		RancherMode: c.GlobalBool("rancher-mode"),
+		LabelNamespace: c.GlobalString("label-namespace"),
 		MetadataURL: c.GlobalString("metadata-url"),
 	})
 	if err != nil {
@@ -67,7 +73,7 @@ func start(c *cli.Context) error {
 		go MetricsServer(handler)
 	}
 
-	events.StartRouter(router, handler)
+	events.StartRouter(router, handler, c.GlobalString("label-namespace"))
 
 	return nil
 }


### PR DESCRIPTION
I have a use case where I want a specific container to stop at certain hour of the day and start at another hour.

This PR allows me to run multiple container-crontab in my Rancher and set cron labels to the same container with different actions.